### PR TITLE
Handle invalid dates for clear chat and download on the frontend

### DIFF
--- a/src/main/java/business_layer/ChatManager.java
+++ b/src/main/java/business_layer/ChatManager.java
@@ -22,7 +22,7 @@ public class ChatManager {
     public ArrayList<ChatMessage> PostMessage(String user, String message) {
         Long chatTime = System.currentTimeMillis();
         ChatMessage messagenew;
-        if(user.equals("") ||user.isEmpty()){
+        if(user == null || user.isEmpty()){
             messagenew = new ChatMessage(message, chatTime);
         }else{
             messagenew = new ChatMessage(user, message, chatTime);

--- a/src/main/java/servlet/ClearServlet.java
+++ b/src/main/java/servlet/ClearServlet.java
@@ -12,6 +12,7 @@ import java.util.Date;
 import java.util.List;
 
 import static helpers.SharedConstants.CHAT_PAGE;
+import static helpers.SharedConstants.DISPLAY_WARNING_POPUP;
 import static helpers.Utils.parseDateTimeLocal;
 
 import business_layer.ChatMessage;
@@ -40,11 +41,9 @@ public class ClearServlet extends HttpServlet {
             List<ChatMessage> filteredMessages = chatManager.ClearMessages(startDate.getTime(), endDate.getTime());
             FrontendChatManager.filterChatWindow(request, filteredMessages);
         } catch (Exception e) {
-            /* Handle end date prior start date case */
+            request.getServletContext().setAttribute(DISPLAY_WARNING_POPUP, "Warning! Start date can not be prior an end date!");
         } finally {
             response.sendRedirect(CHAT_PAGE);
         }
     }
-
-
 }


### PR DESCRIPTION
Display warning if the start date is prior to an end date.

Did a little shuffling for the download function to make sure that none of the code is executed if the dates are not valid.