### PR TITLE
ensure-dynamic-data-is-not-cached-#35

### DIFF
--- a/src/main/java/filters/CacheFilter.java
+++ b/src/main/java/filters/CacheFilter.java
@@ -1,0 +1,27 @@
+package filters;
+
+import javax.servlet.*;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@WebFilter(filterName = "CacheFilter")
+public class CacheFilter implements Filter {
+    public void destroy() {
+    }
+
+    public void doFilter(ServletRequest req, ServletResponse resp, FilterChain chain) throws ServletException, IOException {
+        HttpServletRequest request = (HttpServletRequest) req;
+        HttpServletResponse response = (HttpServletResponse) resp;
+        response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+        response.setHeader("Pragma", "no-cache");
+        response.setDateHeader("Expires", 0);
+        chain.doFilter(req, resp);
+    }
+
+    public void init(FilterConfig config) throws ServletException {
+
+    }
+
+}

--- a/src/main/java/servlet/BasicServlet.java
+++ b/src/main/java/servlet/BasicServlet.java
@@ -61,8 +61,6 @@ public class BasicServlet extends HttpServlet {
                 throw new Exception("End date is prior start date");
             }
 
-            response.setDateHeader("Expires", 0);
-
             if (request.getParameter("format")==null) {
                 response.setContentType("text/plain");
                 response.setHeader("Content-disposition", "attachment; filename=messages.txt");

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -23,6 +23,16 @@
         <url-pattern>/servlet.ClearServlet</url-pattern>
     </servlet-mapping>
 
+    <filter>
+        <filter-name>CacheFilter</filter-name>
+        <filter-class>filters.CacheFilter</filter-class>
+    </filter>
+
+    <filter-mapping>
+        <filter-name>CacheFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
     <welcome-file-list>
         <welcome-file>index.jsp</welcome-file>
     </welcome-file-list>


### PR DESCRIPTION
Add the `CacheControl` filter to ensure that dynamic data is never cached.

- HTTP 1.1 => response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
- HTTP 1.0 => response.setHeader("Pragma", "no-cache");
- Proxies => response.setDateHeader("Expires", 0);

The above header statements should disable caching in any browser and any version of the HTTP protocol.

Filters in JSP work just like interceptors in any other framework. Which means that filter is applied once before servlet and once afterwards.