### PR TITLE
implement-data-encoding-#36

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,16 @@
             <artifactId>jstl</artifactId>
             <version>1.2</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.5</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/filters/EncodingFilter.java
+++ b/src/main/java/filters/EncodingFilter.java
@@ -1,0 +1,23 @@
+package filters;
+
+import javax.servlet.*;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+@WebFilter(filterName = "EncodingFilter")
+public class EncodingFilter implements Filter {
+    public void destroy() {
+    }
+
+    public void doFilter(ServletRequest req, ServletResponse resp, FilterChain chain) throws ServletException, IOException {
+        HttpServletRequest request = (HttpServletRequest) req;
+        request.setCharacterEncoding("UTF-8");
+        chain.doFilter(req, resp);
+    }
+
+    public void init(FilterConfig config) throws ServletException {
+
+    }
+
+}

--- a/src/main/java/servlet/BasicServlet.java
+++ b/src/main/java/servlet/BasicServlet.java
@@ -3,6 +3,7 @@ package servlet;
 import business_layer.ChatManager;
 import business_layer.ChatMessage;
 
+import org.apache.commons.lang.StringEscapeUtils;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -43,7 +44,9 @@ public class BasicServlet extends HttpServlet {
             if(message == null || message.isEmpty()) {
                 throw new Exception("Warning! Message can not be empty!");
             }
-            List<ChatMessage> chatMessages = chatManager.PostMessage(userName, message);
+            String escapedMessage = StringEscapeUtils.escapeXml(message);
+            String escapedUserName = StringEscapeUtils.escapeXml(userName);
+            List<ChatMessage> chatMessages = chatManager.PostMessage(escapedUserName, escapedMessage);
             FrontendChatManager.appendChatWindow(request, chatMessages);
         } catch(Exception e) {
             request.getServletContext().setAttribute(DISPLAY_WARNING_POPUP, e.getMessage());

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -28,6 +28,16 @@
         <filter-class>filters.CacheFilter</filter-class>
     </filter>
 
+    <filter>
+        <filter-name>EncodingFilter</filter-name>
+        <filter-class>filters.EncodingFilter</filter-class>
+    </filter>
+
+    <filter-mapping>
+        <filter-name>EncodingFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
     <filter-mapping>
         <filter-name>CacheFilter</filter-name>
         <url-pattern>/*</url-pattern>


### PR DESCRIPTION
Data encoding issue highlight. Given the following input `<i>name</i>` and `<i>message</i>`
Currently we are getting the following result:
![image](https://user-images.githubusercontent.com/42894823/95668011-b99d4580-0b3b-11eb-819a-0c853f9cfc88.png)

However, we are supposed to get the following:
![image](https://user-images.githubusercontent.com/42894823/95667967-590e0880-0b3b-11eb-8e27-ff28a537ca1b.png)

Current PR solves this problem using these changes:
- Add filter to ensure `UTF-8` character encoding.
- Add `StringEscapeUtils` to Post Message operation to properly escape all illegal characters.

**NOTE: ADDED EXTRA DEPENDENCY TO POM FILE, SO MAKE SURE TO EXECUTE THE FOLLOWING STEPS**
1. Generate Sources and Update Folders
2. Reload project