### PR TITLE
Add JDBC connection and config file #63

### DIFF
--- a/MessageBoardSystem/.gitignore
+++ b/MessageBoardSystem/.gitignore
@@ -8,7 +8,7 @@
 /bin/*
 /target/*
 
-#gradle
+# gradle
 .gradle
 /build
 
@@ -44,9 +44,12 @@ Desktop.ini
 # Recycle Bin used on file shares
 $RECYCLE.BIN/
 
-#Extra Folders
+# Extra Folders
 /unused
 **/.DS_Store
 
-#spring
+# spring
 .springBeans
+
+# Custom configuration
+/config.*

--- a/MessageBoardSystem/README.md
+++ b/MessageBoardSystem/README.md
@@ -1,1 +1,9 @@
 # Message Board System
+
+## Installation
+Add __config.json__ file to the root of __MessageBoardSystem__ module and include the following (MySQL sample):
+- "JDBC_DRIVER":"com.mysql.cj.jdbc.Driver",
+- "DB_URL":"jdbc:mysql://localhost:3306/",
+- "DB_NAME":"preferred_db_name",
+- "DB_USER":"your_username",
+- "DB_PASSWORD":"your_password"

--- a/MessageBoardSystem/pom.xml
+++ b/MessageBoardSystem/pom.xml
@@ -35,6 +35,16 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.22</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.6</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/MessageBoardSystem/src/main/java/configuration/ConfigDriver.java
+++ b/MessageBoardSystem/src/main/java/configuration/ConfigDriver.java
@@ -1,0 +1,53 @@
+package configuration;
+
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.lang.reflect.Type;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class ConfigDriver {
+    private final static String MODULE_NAME = "MessageBoardSystem";
+    private final static String CONFIG_NAME = "config.json";
+    private final static String CONFIG_PATH = Paths.get(System.getProperty("user.dir"), MODULE_NAME, CONFIG_NAME).toString();
+    private final static Gson gson = new Gson();
+    private ConfigDriver() {}
+
+    public static String getJDBCDriver() {
+        return getConfig().get(ConfigModel.JDBC_DRIVER);
+    }
+
+    public static String getDBURL() {
+        return getConfig().get(ConfigModel.DB_URL);
+    }
+
+    public static String getDBName() {
+        return getConfig().get(ConfigModel.DB_NAME);
+    }
+
+    public static String getDBUser() {
+        return getConfig().get(ConfigModel.DB_USER);
+    }
+
+    public static String getDBPassword() {
+        return getConfig().get(ConfigModel.DB_PASSWORD);
+    }
+
+    private static Map<String, String> getConfig() {
+        Map<String, String> configMap = new HashMap<>();
+        try {
+            JsonReader jsonConfigFile = new JsonReader(new FileReader(CONFIG_PATH));
+            Type type = new TypeToken<Map<String, String>>(){}.getType();
+            configMap = gson.fromJson(jsonConfigFile, type);
+        } catch(FileNotFoundException e) {
+            System.err.println("Missing Configuration file.");
+            System.exit(1);
+        }
+        return configMap;
+    }
+}

--- a/MessageBoardSystem/src/main/java/configuration/ConfigModel.java
+++ b/MessageBoardSystem/src/main/java/configuration/ConfigModel.java
@@ -1,0 +1,13 @@
+package configuration;
+
+/*
+* Config file mappings.
+* This file MUST be identical to the local config file at all times.
+* */
+public final class ConfigModel {
+    public final static String JDBC_DRIVER = "JDBC_DRIVER";
+    public final static String DB_URL = "DB_URL";
+    public final static String DB_NAME = "DB_NAME";
+    public final static String DB_USER = "DB_USER";
+    public final static String DB_PASSWORD = "DB_PASSWORD";
+}

--- a/MessageBoardSystem/src/main/java/database/DBConnector.java
+++ b/MessageBoardSystem/src/main/java/database/DBConnector.java
@@ -1,0 +1,51 @@
+package database;
+
+import configuration.ConfigDriver;
+
+import java.sql.*;
+
+public class DBConnector {
+    public static Connection getConnection() {
+        String JDBC_DRIVER = ConfigDriver.getJDBCDriver();
+        String DB_URL = ConfigDriver.getDBURL();
+        String DB_NAME = ConfigDriver.getDBName();
+        String DB_USER = ConfigDriver.getDBUser();
+        String DB_PASSWORD = ConfigDriver.getDBPassword();
+
+        try{
+            Class.forName(JDBC_DRIVER);
+            return DriverManager.getConnection(DB_URL + DB_NAME, DB_USER, DB_PASSWORD);
+        } catch (SQLException e) {
+            throw new RuntimeException("Error connecting to database",e);
+        } catch (ClassNotFoundException e){
+            throw new RuntimeException("Error Class Not Found",e);
+        }
+    }
+
+    public static void releaseConnection(Connection conn, Statement stmt, ResultSet rs) {
+        if (rs != null) {
+            try {
+                rs.close();
+            } catch (SQLException ignored) { }
+            rs = null;
+        }
+
+        releaseConnection(conn, stmt);
+    }
+
+    public static void releaseConnection(Connection conn, Statement stmt) {
+        if (stmt != null) {
+            try {
+                stmt.close();
+            } catch (SQLException ignored) { }
+            stmt = null;
+        }
+
+        if(conn != null) {
+            try {
+                conn.close();
+            } catch (SQLException ignored) { }
+            conn = null;
+        }
+    }
+}


### PR DESCRIPTION
- Add configuration driver for the config retrieval.
- Add JDBC driver for the MySQL connection retrieval.

Configuration driver will automatically pick up **config.json** as long as you place it in the appropriate location.
JDBC driver is used for both connection retrieval and connection release.

**NOTE** Connection variables are retrieved from the **config.json**. Since we all have local versions of the DB, you have to add it yourself. Follow instructions in README to add **config.json**.

Added Dependencies (Make sure to refresh your project):
- mysql-connector-java
- gson