### PR TITLE
Populate predefined users to the DB as a Blob

### DIFF
--- a/MessageBoardSystem/README.md
+++ b/MessageBoardSystem/README.md
@@ -1,9 +1,14 @@
 # Message Board System
 
 ## Installation
-Add __config.json__ file to the root of __MessageBoardSystem__ module and include the following (MySQL sample):
-- "JDBC_DRIVER":"com.mysql.cj.jdbc.Driver",
-- "DB_URL":"jdbc:mysql://localhost:3306/",
-- "DB_NAME":"preferred_db_name",
-- "DB_USER":"your_username",
-- "DB_PASSWORD":"your_password"
+1. Add __config.json__ file to the root of __MessageBoardSystem__ module and include the following (MySQL sample):
+    - "JDBC_DRIVER":"com.mysql.cj.jdbc.Driver",
+    - "DB_URL":"jdbc:mysql://localhost:3306/",
+    - "DB_NAME":"preferred_db_name",
+    - "DB_USER":"your_username",
+    - "DB_PASSWORD":"your_password"
+2. Run `PreloadUsers` driver to add default users to the DB.
+
+## SQL
+- Add `Users` table to store the file with user information:
+`create table Users (UserFile BLOB);`

--- a/MessageBoardSystem/pom.xml
+++ b/MessageBoardSystem/pom.xml
@@ -45,6 +45,12 @@
             <artifactId>gson</artifactId>
             <version>2.8.6</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/com.lambdaworks/scrypt -->
+        <dependency>
+            <groupId>com.lambdaworks</groupId>
+            <artifactId>scrypt</artifactId>
+            <version>1.4.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/MessageBoardSystem/src/main/java/dao/Dao.java
+++ b/MessageBoardSystem/src/main/java/dao/Dao.java
@@ -1,0 +1,8 @@
+package dao;
+
+public interface Dao<T> {
+    void save(T t);
+    void update(int id, T t);
+    void delete(T t);
+    T get(int id);
+}

--- a/MessageBoardSystem/src/main/java/dao/UserDao.java
+++ b/MessageBoardSystem/src/main/java/dao/UserDao.java
@@ -1,0 +1,79 @@
+package dao;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import database.DBConnector;
+import models.User;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class UserDao implements Dao<User> {
+    private final static Gson gson = new Gson();
+
+    public void save(User t) {}
+
+    public void update(int id, User t) {}
+
+    public void delete(User t) {}
+
+    public User get(int userID) {
+        return null;
+    }
+
+    public void initDefaultUsers(List<User> defaultUsers) {
+        String usersJSON = gson.toJson(defaultUsers);
+        InputStream usersBinary = new ByteArrayInputStream(usersJSON.getBytes(StandardCharsets.UTF_8));
+
+        Connection conn = null;
+        PreparedStatement preparedStmt = null;
+        try {
+            String query = "INSERT INTO Users (UserFile) VALUES (?)";
+            conn = DBConnector.getConnection();
+            preparedStmt = conn.prepareStatement(query);
+
+            preparedStmt.setBinaryStream(1, usersBinary);
+
+            preparedStmt.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        } finally {
+            DBConnector.releaseConnection(conn, preparedStmt);
+        }
+    }
+
+    private List<User> getUserFile() {
+        List<User> users = new ArrayList<>();
+        Connection conn = null;
+        Statement stmt = null;
+        ResultSet rs = null;
+
+        try {
+            String query = "SELECT * FROM Users";
+            conn = DBConnector.getConnection();
+            stmt = conn.createStatement();
+
+            rs = stmt.executeQuery(query);
+            rs.next();
+
+            InputStream binaryUsers = rs.getBlob(1).getBinaryStream();
+            Reader reader = new InputStreamReader(binaryUsers);
+
+            Type collectionType = new TypeToken<Collection<User>>(){}.getType();
+            users.addAll(gson.fromJson(reader, collectionType));
+        } catch (SQLException throwables) {
+            throwables.printStackTrace();
+        } finally {
+            DBConnector.releaseConnection(conn, stmt, rs);
+        }
+        return users;
+    }
+}

--- a/MessageBoardSystem/src/main/java/database/DBConnector.java
+++ b/MessageBoardSystem/src/main/java/database/DBConnector.java
@@ -48,4 +48,20 @@ public class DBConnector {
             conn = null;
         }
     }
+
+    public static void releaseConnection(Connection conn, PreparedStatement preparedStmt) {
+        if (preparedStmt != null) {
+            try {
+                preparedStmt.close();
+            } catch (SQLException ignored) { }
+            preparedStmt = null;
+        }
+
+        if(conn != null) {
+            try {
+                conn.close();
+            } catch (SQLException ignored) { }
+            conn = null;
+        }
+    }
 }

--- a/MessageBoardSystem/src/main/java/models/User.java
+++ b/MessageBoardSystem/src/main/java/models/User.java
@@ -1,0 +1,70 @@
+package models;
+
+import com.lambdaworks.crypto.SCryptUtil;
+
+import java.io.Serializable;
+
+public class User implements Serializable {
+    private int userID;
+    private String username;
+    private String email;
+    private String password;
+
+    public User() {}
+    public User(int userID, String username, String email, String password) {
+        this.userID = userID;
+        this.username = username;
+        this.email = email;
+        this.password = this.hashPassword(password);
+    }
+
+    public boolean validPassword(String password) {
+        return SCryptUtil.check(password, this.password);
+    }
+
+    public int getUserID() {
+        return userID;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setUserID(int userID) {
+        this.userID = userID;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    @Override
+    public String toString() {
+        return "User{" +
+                "userID=" + userID +
+                ", username='" + username + '\'' +
+                ", email='" + email + '\'' +
+                ", password='" + password + '\'' +
+                '}';
+    }
+
+    private String hashPassword(String password) {
+        return SCryptUtil.scrypt(password, 16, 16, 16);
+    }
+}

--- a/MessageBoardSystem/src/main/java/preload_data/PreloadUsers.java
+++ b/MessageBoardSystem/src/main/java/preload_data/PreloadUsers.java
@@ -1,0 +1,22 @@
+package preload_data;
+
+import dao.UserDao;
+import models.User;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class PreloadUsers {
+    public static void main(String[] args) {
+        User user1 = new User(1, "Bob", "testemail", "1234");
+        User user2 = new User(2, "Max", "max@gmail.com", "qwerty");
+        User user3 = new User(3, "Sara", "sara@yahoo.com", "somePassword");
+        User user4 = new User(4, "Maya", "maya@someEmail.com", "password");
+
+        List<User> defaultUsers = new ArrayList<>(Arrays.asList(user1, user2, user3, user4));
+        UserDao userDao = new UserDao();
+
+        userDao.initDefaultUsers(defaultUsers);
+    }
+}


### PR DESCRIPTION
Add 4 default users.
- Create `Users` table to store users file as a Blob.
- Add `PreloadUsers` class to programmatically populate DB with predefined users.
- Add DAO interface
- Add UserDAO 
- Add User Model

**NOTE** User password is immediately hashed on the object creation.

**New dependency** SCrypt - to hash password.

**CONFIG NOTE** We must keep `config.json` in the root dir of `MessageBoardSystem`. It means that we need to keep two copies of the config. We would remove the config file when `sign-up` functionality is in place. Otherwise, if we want to populate DB programmatically, we need to keep it.
