### PR TITLE
Move config file to the WEB-INf folder

### DIFF
--- a/MessageBoardSystem/.gitignore
+++ b/MessageBoardSystem/.gitignore
@@ -52,4 +52,4 @@ $RECYCLE.BIN/
 .springBeans
 
 # Custom configuration
-/config.*
+/src/main/webapp/WEB-INF/config.json

--- a/MessageBoardSystem/README.md
+++ b/MessageBoardSystem/README.md
@@ -1,7 +1,7 @@
 # Message Board System
 
 ## Installation
-1. Add __config.json__ file to the root of __MessageBoardSystem__ module and include the following (MySQL sample):
+1. Add __config.json__ file to the root of __WEB-INF__ folder and include the following (MySQL sample):
     - "JDBC_DRIVER":"com.mysql.cj.jdbc.Driver",
     - "DB_URL":"jdbc:mysql://localhost:3306/",
     - "DB_NAME":"preferred_db_name",

--- a/MessageBoardSystem/pom.xml
+++ b/MessageBoardSystem/pom.xml
@@ -64,8 +64,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>9</source>
-                    <target>9</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/MessageBoardSystem/src/main/java/configuration/ConfigDriver.java
+++ b/MessageBoardSystem/src/main/java/configuration/ConfigDriver.java
@@ -1,20 +1,21 @@
 package configuration;
 
-import java.io.FileNotFoundException;
 import java.io.FileReader;
+import java.io.IOException;
 import java.lang.reflect.Type;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 public final class ConfigDriver {
-    private final static String MODULE_NAME = "MessageBoardSystem";
     private final static String CONFIG_NAME = "config.json";
-    private final static String CONFIG_PATH = Paths.get(System.getProperty("user.dir"), MODULE_NAME, CONFIG_NAME).toString();
     private final static Gson gson = new Gson();
     private ConfigDriver() {}
 
@@ -41,13 +42,26 @@ public final class ConfigDriver {
     private static Map<String, String> getConfig() {
         Map<String, String> configMap = new HashMap<>();
         try {
-            JsonReader jsonConfigFile = new JsonReader(new FileReader(CONFIG_PATH));
+            String configPath = buildConfigPath();
+            JsonReader jsonConfigFile = new JsonReader(new FileReader(configPath));
             Type type = new TypeToken<Map<String, String>>(){}.getType();
             configMap = gson.fromJson(jsonConfigFile, type);
-        } catch(FileNotFoundException e) {
+        } catch(IOException e) {
             System.err.println("Missing Configuration file.");
             System.exit(1);
         }
         return configMap;
+    }
+
+    private static String buildConfigPath() throws IOException {
+        Path rootPath = Paths.get(System.getProperty("user.dir")).toAbsolutePath().normalize();
+        if(rootPath.toString().contains("tomcat")) {
+            rootPath = rootPath.getParent();
+        }
+        Optional<Path> hit = Files.walk(rootPath)
+                .filter(file -> file.getFileName().toString().equals(CONFIG_NAME))
+                .findAny();
+
+        return hit.get().toString();
     }
 }


### PR DESCRIPTION
Keep the configuration file in the WEB-INF folder.
This way we can share config information between local startup and Tomcat deployment because WEB-INF is shared in a WAR file. Config Driver should automatically traverse the project tree and find config.

**NOTE** WEB-INF is also protected from the public and can be used only to programmatically read resources. Which makes it a perfect location for the job.

**ACTIONS** Make sure to keep a single instance of `config.json` in a root dir of WEB-INF folder.
![image](https://user-images.githubusercontent.com/42894823/97921538-151cb680-1d29-11eb-8bee-1b5f5b4fc65d.png)
