### PR TITLE
Add attachment upload #57

### DIFF
--- a/MessageBoardSystem/README.md
+++ b/MessageBoardSystem/README.md
@@ -2,7 +2,6 @@
 
 ## Database
 - Use the following query to create the posts table.
-
 ```
 CREATE TABLE `posts` (
  `postID` int(11) NOT NULL AUTO_INCREMENT,
@@ -10,9 +9,19 @@ CREATE TABLE `posts` (
  `postTitle` varchar(96) NOT NULL,
  `timestamp` bigint(30) NOT NULL,
  `message` varchar(1024) NOT NULL,
- `attachment` blob DEFAULT NULL,
  PRIMARY KEY (`postID`)
 ) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8mb4
+```
+
+- Add `AttachmentInfo` table to store information about attachments
+```
+CREATE TABLE Attachments (
+postID int NOT NULL,
+fileName varchar(255) NOT NULL,
+fileSize bigint(30) NOT NULL,
+mediaType varchar(255) NOT NULL,
+attachment longblob NOT NULL,
+PRIMARY KEY(postID));
 ```
 
 - Add `Users` table to store the file with user information:

--- a/MessageBoardSystem/src/main/java/business_layer/MessageBoardManager.java
+++ b/MessageBoardSystem/src/main/java/business_layer/MessageBoardManager.java
@@ -1,17 +1,29 @@
 package business_layer;
 
+import dao.AttachmentDao;
 import dao.PostDao;
+import models.Attachment;
 import models.Post;
 import dao.UserDao;
 import models.User;
 
+import java.io.InputStream;
+
 public class MessageBoardManager {
     private final UserDao userDao;
     private final PostDao postDao;
+    private final AttachmentDao attachmentDao;
 
     public MessageBoardManager() {
-        userDao = new UserDao();
-        postDao = new PostDao();
+        this.userDao = new UserDao();
+        this.postDao = new PostDao();
+        this.attachmentDao = new AttachmentDao();
+    }
+
+    public void saveAttachment(Post post, String fileName, long fileSize, String mediaType, InputStream attachmentBinary) {
+        Attachment attachment = new Attachment(post.getPostID(), fileName, fileSize, mediaType, attachmentBinary);
+        this.attachmentDao.save(attachment);
+        post.setAttachmentFromBinary(this.attachmentDao.getAttachmentBinary(post.getPostID()));
     }
 
     public Post postMessage(int userID, String title, String message) {

--- a/MessageBoardSystem/src/main/java/dao/AttachmentDao.java
+++ b/MessageBoardSystem/src/main/java/dao/AttachmentDao.java
@@ -1,0 +1,68 @@
+package dao;
+
+import database.DBConnector;
+import models.Attachment;
+
+import java.io.InputStream;
+import java.sql.*;
+
+public class AttachmentDao implements Dao<Attachment> {
+
+    public InputStream getAttachmentBinary(int postID) {
+        Connection conn = null;
+        PreparedStatement preparedStmt = null;
+        ResultSet rs = null;
+        String query = "SELECT attachment FROM Attachments WHERE postID = ?";
+
+        try {
+            conn = DBConnector.getConnection();
+            preparedStmt = conn.prepareStatement(query);
+            preparedStmt.setInt(1, postID);
+
+            rs = preparedStmt.executeQuery();
+            if(rs.next()) {
+                Blob attachmentBlob = rs.getBlob("attachment");
+                return attachmentBlob.getBinaryStream();
+            }
+        } catch (SQLException throwables) {
+            throwables.printStackTrace();
+        } finally {
+            DBConnector.releaseConnection(conn, preparedStmt, rs);
+        }
+        return null;
+    }
+
+    @Override
+    public void save(Attachment attachment) {
+        Connection conn = null;
+        PreparedStatement preparedStmt = null;
+        String query = "INSERT INTO Attachments (postID, fileName, fileSize, mediaType, attachment) VALUES (?,?,?,?,?)";
+
+        try {
+            conn = DBConnector.getConnection();
+            preparedStmt = conn.prepareStatement(query);
+
+            preparedStmt.setInt(1, attachment.getPostID());
+            preparedStmt.setString(2, attachment.getFileName());
+            preparedStmt.setLong(3, attachment.getFileSize());
+            preparedStmt.setString(4, attachment.getMediaType());
+            preparedStmt.setBinaryStream(5, attachment.getAttachmentBinary());
+
+            preparedStmt.executeUpdate();
+        } catch (SQLException throwables) {
+            throwables.printStackTrace();
+        } finally {
+            DBConnector.releaseConnection(conn, preparedStmt);
+        }
+    }
+
+    @Override
+    public void update(int id, Attachment attachment) {
+
+    }
+
+    @Override
+    public void delete(Attachment attachment) {
+
+    }
+}

--- a/MessageBoardSystem/src/main/java/dao/PostDao.java
+++ b/MessageBoardSystem/src/main/java/dao/PostDao.java
@@ -3,31 +3,34 @@ package dao;
 import database.DBConnector;
 import models.Post;
 
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
+import java.sql.*;
 
 public class PostDao implements Dao<Post> {
 
     public void save(Post post){
-        Connection c = DBConnector.getConnection();
-        Statement stmt = null;
+        Connection conn = null;
+        PreparedStatement preparedStmt = null;
         ResultSet rs = null;
-        String query = String.format("INSERT INTO posts (userID, postTitle, message, timestamp) VALUES ('%s', '%s', '%s', %s)", post.getUserID(), post.getPostTitle(), post.getMessage(), post.getTimestamp());
+        String query = "INSERT INTO posts (userID, postTitle, message, timestamp) VALUES (?,?,?,?)";
 
         try {
-            stmt = c.prepareStatement(query);
-            stmt.executeUpdate(query, Statement.RETURN_GENERATED_KEYS);
+            conn = DBConnector.getConnection();
+            preparedStmt = conn.prepareStatement(query, Statement.RETURN_GENERATED_KEYS);
 
-            rs = stmt.getGeneratedKeys();
+            preparedStmt.setInt(1, post.getUserID());
+            preparedStmt.setString(2, post.getPostTitle());
+            preparedStmt.setString(3, post.getMessage());
+            preparedStmt.setLong(4, post.getTimestamp());
+            preparedStmt.executeUpdate();
+
+            rs = preparedStmt.getGeneratedKeys();
             if(rs.next()) {
                 post.setPostID(rs.getInt(1));
             }
         } catch (SQLException throwables) {
             throwables.printStackTrace();
         } finally {
-            DBConnector.releaseConnection(c, stmt, rs);
+            DBConnector.releaseConnection(conn, preparedStmt, rs);
         }
     }
 

--- a/MessageBoardSystem/src/main/java/helpers/Utils.java
+++ b/MessageBoardSystem/src/main/java/helpers/Utils.java
@@ -1,0 +1,26 @@
+package helpers;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.util.Base64;
+
+public class Utils {
+    public static String inputStreamToImage(InputStream stream) {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        byte[] buffer = new byte[4096];
+        String base64Image = "";
+        int bytesRead = -1;
+
+        try {
+            while ((bytesRead = stream.read(buffer)) != -1) {
+                outputStream.write(buffer, 0, bytesRead);
+            }
+            byte[] imageBytes = outputStream.toByteArray();
+            base64Image = Base64.getEncoder().encodeToString(imageBytes);
+            outputStream.close();
+            stream.close();
+        } catch (Exception ignore) {}
+
+        return base64Image;
+    }
+}

--- a/MessageBoardSystem/src/main/java/models/Attachment.java
+++ b/MessageBoardSystem/src/main/java/models/Attachment.java
@@ -1,0 +1,72 @@
+package models;
+
+import java.io.InputStream;
+import java.io.Serializable;
+
+public class Attachment implements Serializable {
+    private int postID;
+    private String fileName;
+    private long fileSize;
+    private String mediaType;
+    private InputStream attachmentBinary;
+
+    public Attachment() {}
+    public Attachment(int postID, String fileName, long fileSize, String mediaType, InputStream attachmentBinary) {
+        this.postID = postID;
+        this.fileName = fileName;
+        this.fileSize = fileSize;
+        this.mediaType = mediaType;
+        this.attachmentBinary = attachmentBinary;
+    }
+
+    public InputStream getAttachmentBinary() {
+        return attachmentBinary;
+    }
+
+    public void setAttachmentBinary(InputStream attachmentBinary) {
+        this.attachmentBinary = attachmentBinary;
+    }
+
+    public int getPostID() {
+        return postID;
+    }
+
+    public void setPostID(int postID) {
+        this.postID = postID;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public long getFileSize() {
+        return fileSize;
+    }
+
+    public void setFileSize(long fileSize) {
+        this.fileSize = fileSize;
+    }
+
+    public String getMediaType() {
+        return mediaType;
+    }
+
+    public void setMediaType(String mediaType) {
+        this.mediaType = mediaType;
+    }
+
+
+    @Override
+    public String toString() {
+        return "Attachment{" +
+                "postID=" + postID +
+                ", fileName='" + fileName + '\'' +
+                ", fileSize=" + fileSize +
+                ", mediaType='" + mediaType + '\'' +
+                '}';
+    }
+}

--- a/MessageBoardSystem/src/main/java/models/Post.java
+++ b/MessageBoardSystem/src/main/java/models/Post.java
@@ -1,5 +1,8 @@
 package models;
 
+import helpers.Utils;
+
+import java.io.InputStream;
 import java.io.Serializable;
 
 public class Post implements Serializable {
@@ -8,6 +11,8 @@ public class Post implements Serializable {
     private String postTitle;
     private String message;
     private long timestamp;
+    private String attachment;
+    private boolean containsAttachment;
 
     public Post() {}
     public Post(int userID, String postTitle, String message, long timestamp) {
@@ -15,6 +20,30 @@ public class Post implements Serializable {
         this.postTitle = postTitle;
         this.message = message;
         this.timestamp = timestamp;
+        this.containsAttachment = false;
+    }
+
+    public void setAttachmentFromBinary(InputStream stream) {
+        if(stream != null) {
+            this.containsAttachment = true;
+            this.attachment = Utils.inputStreamToImage(stream);
+        }
+    }
+
+    public String getAttachment() {
+        return attachment;
+    }
+
+    public void setAttachment(String attachment) {
+        this.attachment = attachment;
+    }
+
+    public boolean isContainsAttachment() {
+        return containsAttachment;
+    }
+
+    public void setContainsAttachment(boolean containsAttachment) {
+        this.containsAttachment = containsAttachment;
     }
 
     public int getUserID() {

--- a/MessageBoardSystem/src/main/java/servlet/BasicServlet.java
+++ b/MessageBoardSystem/src/main/java/servlet/BasicServlet.java
@@ -5,25 +5,35 @@ import helpers.FrontendBoardManager;
 import models.Post;
 
 import javax.servlet.ServletException;
+import javax.servlet.annotation.MultipartConfig;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.Part;
 import java.io.IOException;
 
 import static helpers.Constants.ROOT_PAGE;
 
 @WebServlet(name = "BasicServlet")
+@MultipartConfig
 public class BasicServlet extends HttpServlet {
     MessageBoardManager boardManager = new MessageBoardManager();
 
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         String message = request.getParameter("message");
         String title = request.getParameter("title");
+        Part attachmentPart = request.getPart("attachment");
         int userID = (int) request.getSession().getAttribute("userID");
 
         if(message != null && title != null && !message.isEmpty() && !title.isEmpty()) {
             Post post = boardManager.postMessage(userID, title, message);
+
+            if(attachmentPart.getSize() > 0) {
+                this.boardManager.saveAttachment(post, attachmentPart.getSubmittedFileName(), attachmentPart.getSize(),
+                        attachmentPart.getContentType(), attachmentPart.getInputStream());
+
+            }
             FrontendBoardManager.appendMessageBoard(request, post);
         }
 

--- a/MessageBoardSystem/src/main/webapp/createPost.jsp
+++ b/MessageBoardSystem/src/main/webapp/createPost.jsp
@@ -16,7 +16,7 @@
     <c:redirect url="index.jsp"/>
 </c:if>
 
-<form method="post" action="servlet.BasicServlet">
+<form method="post" action="servlet.BasicServlet" enctype="multipart/form-data">
     <div class="form-group row">
         <label for="title" class="col-sm-2 col-form-label">Title</label>
         <div class="col-sm-10">
@@ -31,7 +31,7 @@
     </div>
     <div class="form-group">
         <label for="inputAttachment" class="col-sm-2 col-form-label">Attachment</label>
-        <input type="file" class="form-control-file" id="inputAttachment">
+        <input name="attachment" type="file" class="form-control-file" id="inputAttachment">
     </div>
     <div class="form-group row">
         <div class="col-sm-10">

--- a/MessageBoardSystem/src/main/webapp/main.jsp
+++ b/MessageBoardSystem/src/main/webapp/main.jsp
@@ -37,9 +37,12 @@
 <c:choose>
     <c:when test="${not empty messageBoard}">
         <jsp:useBean id="messageBoard" type="java.util.concurrent.ConcurrentSkipListMap<java.lang.Long, models.Post>" scope="application"/>
-        <div style="margin-top: 40px">
+        <div style="margin-top: 60px; margin-left:40%">
             <c:forEach items="${messageBoard.values()}" var="post">
-                <div class="card">
+                <div class="card" style="width: 25rem;" >
+                    <c:if test = "${post.containsAttachment}">
+                        <img src="data:image/jpg;base64,${post.attachment}" class="card-img-top" alt="No attachment">
+                    </c:if>
                     <div class="card-body">
                         <h5 class="card-title">${post.postTitle}</h5>
                         <p class="card-text">${post.message}</p>


### PR DESCRIPTION
Add attachment upload for the Create Post functionality. I removed the attachment from the `Post` because it did not really work out in terms of flow. So, we are keeping everything related to attachments in a separate table.

- Add a new `Attachments` table. The new `CREATE TABLE` query is in README.
- Add AttachmentDao to store attachments and fetch attachment binary.

**NOTE** `Posts` table has also changed, so make sure to refresh it. 