### PR TITLE
normalize table names #108

### DIFF
--- a/MessageBoardSystem/README.md
+++ b/MessageBoardSystem/README.md
@@ -3,7 +3,7 @@
 ## Database
 - Use the following query to create the posts table.
 ```
-CREATE TABLE `posts` (
+CREATE TABLE `post` (
  `postID` int(11) NOT NULL AUTO_INCREMENT,
  `userID` int(11) NOT NULL,
  `username` varchar(96) NOT NULL,
@@ -18,13 +18,14 @@ CREATE TABLE `posts` (
 
 - Add `AttachmentInfo` table to store information about attachments
 ```
-CREATE TABLE Attachments (
+CREATE TABLE attachment (
 postID int NOT NULL,
 fileName varchar(255) NOT NULL,
 fileSize bigint(30) NOT NULL,
 mediaType varchar(255) NOT NULL,
 attachment longblob NOT NULL,
-PRIMARY KEY(postID));
+PRIMARY KEY(postID),
+FOREIGN KEY(postID) REFERENCES post(postID) ON DELETE CASCADE);
 ```
 
 - Add `hastag` table to store information about hashtag
@@ -33,7 +34,7 @@ CREATE TABLE hashtag (
 hashtag varchar(255) NOT NULL,
 postID int NOT NULL,
 PRIMARY KEY(hashtag,postID),
-FOREIGN KEY(postID) REFERENCES posts(postID) ON DELETE CASCADE);
+FOREIGN KEY(postID) REFERENCES post(postID) ON DELETE CASCADE);
 ```
 
 ## Installation

--- a/MessageBoardSystem/src/main/java/business_layer/MessageBoardManager.java
+++ b/MessageBoardSystem/src/main/java/business_layer/MessageBoardManager.java
@@ -57,7 +57,6 @@ public class MessageBoardManager {
     }
 
     public boolean deletePost(int postID) {
-        this.attachmentDao.delete(postID);
         return this.postDao.delete(postID);
     }
 

--- a/MessageBoardSystem/src/main/java/dao/AttachmentDao.java
+++ b/MessageBoardSystem/src/main/java/dao/AttachmentDao.java
@@ -11,7 +11,7 @@ public class AttachmentDao implements Dao<Attachment> {
         Connection conn = null;
         PreparedStatement preparedStmt = null;
         ResultSet rs = null;
-        String query = "SELECT * FROM Attachments WHERE postID = ?";
+        String query = "SELECT * FROM attachment WHERE postID = ?";
 
         try {
             conn = DBConnector.getConnection();
@@ -44,7 +44,7 @@ public class AttachmentDao implements Dao<Attachment> {
     public void save(Attachment attachment) {
         Connection conn = null;
         PreparedStatement preparedStmt = null;
-        String query = "INSERT INTO Attachments (postID, fileName, fileSize, mediaType, attachment) VALUES (?,?,?,?,?)";
+        String query = "INSERT INTO attachment (postID, fileName, fileSize, mediaType, attachment) VALUES (?,?,?,?,?)";
 
         try {
             conn = DBConnector.getConnection();
@@ -68,7 +68,7 @@ public class AttachmentDao implements Dao<Attachment> {
     public void update(Attachment attachment) {
         Connection conn = null;
         PreparedStatement preparedStmt = null;
-        String query = "UPDATE Attachments SET fileName=?,fileSize=?,mediaType=?,attachment=? WHERE postID=?";
+        String query = "UPDATE attachment SET fileName=?,fileSize=?,mediaType=?,attachment=? WHERE postID=?";
 
         try {
             conn = DBConnector.getConnection();
@@ -92,7 +92,7 @@ public class AttachmentDao implements Dao<Attachment> {
     public boolean delete(int postID) {
         Connection conn = null;
         PreparedStatement preparedStmt = null;
-        String query = "DELETE FROM Attachments WHERE postID=?";
+        String query = "DELETE FROM attachment WHERE postID=?";
         boolean deleteStatus = false;
 
         try {

--- a/MessageBoardSystem/src/main/java/dao/PostDao.java
+++ b/MessageBoardSystem/src/main/java/dao/PostDao.java
@@ -12,7 +12,7 @@ public class PostDao implements Dao<Post> {
         Connection conn = null;
         PreparedStatement preparedStmt = null;
         ResultSet rs = null;
-        String query = "INSERT INTO posts (userID, username, postTitle,message, timestamp, dateString, lastModifiedTimestamp) VALUES (?,?,?,?,?,?,?)";
+        String query = "INSERT INTO post (userID, username, postTitle, message, timestamp, dateString, lastModifiedTimestamp) VALUES (?,?,?,?,?,?,?)";
 
         try {
             conn = DBConnector.getConnection();
@@ -41,7 +41,7 @@ public class PostDao implements Dao<Post> {
     public void update(Post post) {
         Connection conn = null;
         PreparedStatement preparedStmt = null;
-        String query = "UPDATE posts SET postTitle=?, message=? WHERE postID=?";
+        String query = "UPDATE post SET postTitle=?, message=? WHERE postID=?";
 
         try {
             conn = DBConnector.getConnection();
@@ -62,7 +62,7 @@ public class PostDao implements Dao<Post> {
         Connection conn = null;
         PreparedStatement preparedStmt = null;
         ResultSet rs = null;
-        String query = "SELECT * FROM posts WHERE postID=?";
+        String query = "SELECT * FROM post WHERE postID=?";
         Post post = null;
 
         try {
@@ -88,7 +88,7 @@ public class PostDao implements Dao<Post> {
     public boolean delete(int postID) {
         Connection conn = null;
         PreparedStatement preparedStmt = null;
-        String query = "DELETE FROM posts WHERE postID=?";
+        String query = "DELETE FROM post WHERE postID=?";
         boolean deleteStatus = false;
 
         try{
@@ -112,7 +112,7 @@ public class PostDao implements Dao<Post> {
         Connection conn = null;
         PreparedStatement preparedStmt = null;
         ResultSet rs = null;
-        String query = "SELECT * FROM posts";
+        String query = "SELECT * FROM post";
 
         try {
             conn = DBConnector.getConnection();
@@ -139,7 +139,7 @@ public class PostDao implements Dao<Post> {
         Connection conn = null;
         PreparedStatement preparedStmt = null;
         ResultSet rs = null;
-        String query = "SELECT * FROM posts WHERE dateString=?";
+        String query = "SELECT * FROM post WHERE dateString=?";
 
         try {
             conn = DBConnector.getConnection();
@@ -163,7 +163,7 @@ public class PostDao implements Dao<Post> {
         Connection conn = null;
         PreparedStatement preparedStmt = null;
         ResultSet rs = null;
-        String query = "SELECT * FROM posts WHERE username=?";
+        String query = "SELECT * FROM post WHERE username=?";
 
         try {
             conn = DBConnector.getConnection();
@@ -187,7 +187,7 @@ public class PostDao implements Dao<Post> {
         Connection conn = null;
         PreparedStatement preparedStmt = null;
         ResultSet rs = null;
-        String query = "SELECT * FROM posts ORDER BY timestamp DESC LIMIT ?";
+        String query = "SELECT * FROM post ORDER BY timestamp DESC LIMIT ?";
 
         try {
             conn = DBConnector.getConnection();
@@ -213,7 +213,7 @@ public class PostDao implements Dao<Post> {
     public void updateModificationTime(int postID, long modificationTimestamp) {
         Connection conn = null;
         PreparedStatement preparedStmt = null;
-        String query = "UPDATE posts SET lastModifiedTimestamp=? WHERE postID=?";
+        String query = "UPDATE post SET lastModifiedTimestamp=? WHERE postID=?";
 
         try {
             conn = DBConnector.getConnection();


### PR DESCRIPTION
MySQL naming convention for the table names is **lowercase** and **singular**
- Fix table names
- Add `FOREIGN KEY` to the attachment table

**NOTE** Make sure to recreate all your tables