### PR TITLE
Add unit tests for circular dependency and missing parent #127

### DIFF
--- a/MessageBoardSystem/.gitignore
+++ b/MessageBoardSystem/.gitignore
@@ -53,3 +53,4 @@ $RECYCLE.BIN/
 
 # Custom configuration
 /src/main/webapp/WEB-INF/config.json
+**/*.png

--- a/MessageBoardSystem/src/main/java/business_layer/UserManager.java
+++ b/MessageBoardSystem/src/main/java/business_layer/UserManager.java
@@ -1,0 +1,14 @@
+package business_layer;
+import java.util.*;
+
+public class UserManager {
+    private final static String USER_FILE_NAME = "users.json";
+
+    public Set<String> loadGroupMembership() {
+        return this.loadGroupMembership(USER_FILE_NAME);
+    }
+
+    public Set<String> loadGroupMembership(String userConfig) {
+        return null;
+    }
+}

--- a/MessageBoardSystem/src/main/webapp/WEB-INF/users.json
+++ b/MessageBoardSystem/src/main/webapp/WEB-INF/users.json
@@ -1,6 +1,44 @@
-[
-  {"userID":1,"username":"Bob","email":"testemail","password":"$s0$41010$mIYQ8jmiyU5BstiQTsm83g\u003d\u003d$fcd0fYCJDXYvyXdSzC8eZ+kQEYfujZdCoC47rP2Cfzs\u003d"},
-  {"userID":2,"username":"Max","email":"max@gmail.com","password":"$s0$41010$5Qp+xmp7HA3RaroGxf+iRQ\u003d\u003d$ISozgujnuAU/dsWSeGT6LK0hwrLYSA4Zl1KhhhYEcBI\u003d"},
-  {"userID":3,"username":"Sara","email":"sara@yahoo.com","password":"$s0$41010$RO4df9jZ486LWJH+2ZPAEQ\u003d\u003d$bJooftgH7zHjAmE/30677UpbJlvW7nH540bm9IiWXvE\u003d"},
-  {"userID":4,"username":"Maya","email":"maya@someEmail.com","password":"$s0$41010$PYRZe/wVzO9qCDqPF80vMA\u003d\u003d$6CJ3I775HohcJm2GCyG8A7/9DGEfJuhtisQ0HBuWYsA\u003d"}
-]
+{
+  "users": [
+    {"userID":1,"username":"Bob","email":"testemail","password":"$s0$41010$mIYQ8jmiyU5BstiQTsm83g\u003d\u003d$fcd0fYCJDXYvyXdSzC8eZ+kQEYfujZdCoC47rP2Cfzs\u003d"},
+    {"userID":2,"username":"Max","email":"max@gmail.com","password":"$s0$41010$5Qp+xmp7HA3RaroGxf+iRQ\u003d\u003d$ISozgujnuAU/dsWSeGT6LK0hwrLYSA4Zl1KhhhYEcBI\u003d"},
+    {"userID":3,"username":"Sara","email":"sara@yahoo.com","password":"$s0$41010$RO4df9jZ486LWJH+2ZPAEQ\u003d\u003d$bJooftgH7zHjAmE/30677UpbJlvW7nH540bm9IiWXvE\u003d"},
+    {"userID":4,"username":"Maya","email":"maya@someEmail.com","password":"$s0$41010$PYRZe/wVzO9qCDqPF80vMA\u003d\u003d$6CJ3I775HohcJm2GCyG8A7/9DGEfJuhtisQ0HBuWYsA\u003d"}
+  ],
+  "groups": [
+    {
+      "name": "admins",
+      "parent": null
+    },
+    {
+      "name": "concordia",
+      "parent": null
+    },
+    {
+      "name": "encs",
+      "parent": "concordia"
+    },
+    {
+      "name": "comp",
+      "parent": "encs"
+    },
+    {
+      "name": "soen",
+      "parent": "encs"
+    }
+  ],
+  "memberships": [
+    {
+      "username": "Bob",
+      "userGroups": ["admins", "concordia"]
+    },
+    {
+      "username": "Max",
+      "userGroups": ["encs"]
+    },
+    {
+      "username": "Sara",
+      "userGroups": ["soen"]
+    }
+  ]
+}

--- a/MessageBoardSystem/src/test/java/UserManagerTest.java
+++ b/MessageBoardSystem/src/test/java/UserManagerTest.java
@@ -1,0 +1,31 @@
+import business_layer.UserManager;
+import org.junit.Before;
+import org.junit.Test;
+
+public class UserManagerTest {
+    private static final String CIRCULAR_DEPENDENCY_DIFFERENT_GROUP_TEST_DATA = "circularDependencyDifferentGroup.json";
+    private static final String CIRCULAR_DEPENDENCY_SAME_GROUP_DATA = "circularDependencySameGroup.json";
+    private static final String MISSING_PARENT_GROUP_DATA = "missingParentData.json";
+
+    UserManager userManager = null;
+
+    @Before
+    public void before() {
+        userManager = new UserManager();
+    }
+
+    @Test(expected = Exception.class)
+    public void testCircularDependencyDifferentGroup() {
+        userManager.loadGroupMembership(CIRCULAR_DEPENDENCY_DIFFERENT_GROUP_TEST_DATA);
+    }
+
+    @Test(expected = Exception.class)
+    public void testCircularDependencySameGroup() {
+        userManager.loadGroupMembership(CIRCULAR_DEPENDENCY_SAME_GROUP_DATA);
+    }
+
+    @Test(expected = Exception.class)
+    public void testMissingParentGroup() {
+        userManager.loadGroupMembership(MISSING_PARENT_GROUP_DATA);
+    }
+}

--- a/MessageBoardSystem/src/test/resources/circularDependencyDifferentGroup.json
+++ b/MessageBoardSystem/src/test/resources/circularDependencyDifferentGroup.json
@@ -1,0 +1,30 @@
+{
+  "users": [
+    {"userID":1,"username":"Bob"},
+    {"userID":2,"username":"Max"}
+  ],
+  "groups": [
+    {
+      "name": "admins",
+      "parent": null
+    },
+    {
+      "name": "concordia",
+      "parent": "encs"
+    },
+    {
+      "name": "encs",
+      "parent": "concordia"
+    }
+  ],
+  "memberships": [
+    {
+      "username": "Bob",
+      "userGroups": ["admins", "concordia"]
+    },
+    {
+      "username": "Max",
+      "userGroups": ["encs", "concordia"]
+    }
+  ]
+}

--- a/MessageBoardSystem/src/test/resources/circularDependencySameGroup.json
+++ b/MessageBoardSystem/src/test/resources/circularDependencySameGroup.json
@@ -1,0 +1,26 @@
+{
+  "users": [
+    {"userID":1,"username":"Bob"},
+    {"userID":2,"username":"Max"}
+  ],
+  "groups": [
+    {
+      "name": "admins",
+      "parent": null
+    },
+    {
+      "name": "concordia",
+      "parent": "concordia"
+    }
+  ],
+  "memberships": [
+    {
+      "username": "Bob",
+      "userGroups": ["admins"]
+    },
+    {
+      "username": "Max",
+      "userGroups": ["admins", "concordia"]
+    }
+  ]
+}

--- a/MessageBoardSystem/src/test/resources/missingParentData.json
+++ b/MessageBoardSystem/src/test/resources/missingParentData.json
@@ -1,0 +1,26 @@
+{
+  "users": [
+    {"userID":1,"username":"Bob"},
+    {"userID":2,"username":"Max"}
+  ],
+  "groups": [
+    {
+      "name": "admins",
+      "parent": null
+    },
+    {
+      "name": "encs",
+      "parent": "concordia"
+    }
+  ],
+  "memberships": [
+    {
+      "username": "Bob",
+      "userGroups": ["admins", "encs"]
+    },
+    {
+      "username": "Max",
+      "userGroups": ["concordia"]
+    }
+  ]
+}


### PR DESCRIPTION
- 2 tests for the circular dependency:
    - Circular dependency between two different groups
    - Self-cycle for the specific group
- 1 test for the missing parent group

All tests must fail with a **thrown Exception**.

Each test uses completely independent data. **@Before** section is added to ensure that no data overflows between the tests.