### PR TITLE
Add separated interface and singleton factory #120 #121

### DIFF
--- a/MessageBoardSystem/src/main/java/business_layer/IUserManager.java
+++ b/MessageBoardSystem/src/main/java/business_layer/IUserManager.java
@@ -1,0 +1,10 @@
+package business_layer;
+
+import models.User;
+
+import java.util.Set;
+
+public interface IUserManager {
+    Set<String> loadGroupMembership(String username) throws Exception;
+    User getUser(String email, String password);
+}

--- a/MessageBoardSystem/src/main/java/business_layer/MessageBoardManager.java
+++ b/MessageBoardSystem/src/main/java/business_layer/MessageBoardManager.java
@@ -15,13 +15,14 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class MessageBoardManager {
-    private final UserManager userManager;
+    private final static String USER_FILE_NAME = "users.json";
+    private final IUserManager userManager;
     private final PostDao postDao;
     private final AttachmentDao attachmentDao;
     private final HashtagDao hashtagDao;
 
     public MessageBoardManager() {
-        this.userManager = new UserManager();
+        this.userManager = UserManagerFactory.getInstance().createUserManager(USER_FILE_NAME);
         this.postDao = new PostDao();
         this.attachmentDao = new AttachmentDao();
         this.hashtagDao = new HashtagDao();

--- a/MessageBoardSystem/src/main/java/business_layer/UserManagerFactory.java
+++ b/MessageBoardSystem/src/main/java/business_layer/UserManagerFactory.java
@@ -1,0 +1,49 @@
+package business_layer;
+
+import configuration.ConfigDriver;
+import helpers.Utils;
+
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+public final class UserManagerFactory {
+    private UserManagerFactory(){}
+
+    private static UserManagerFactory factoryInstance = null;
+
+    public static UserManagerFactory getInstance() {
+        if(factoryInstance == null){
+            synchronized(UserManagerFactory.class) {
+                if(factoryInstance == null)
+                    factoryInstance = new UserManagerFactory();
+            }
+        }
+        return factoryInstance;
+    }
+
+    public IUserManager createUserManager(String userFileName) {
+        IUserManager userManager = null;
+        try {
+            String userFilePath = Utils.buildTargetFilePath(userFileName);
+            Class<?> cl = Class.forName(ConfigDriver.getUserManagerClassName());
+            Class<?>[] type = { String.class };
+            Constructor<?> cons = cl.getConstructor(type);
+            Object[] obj = { userFilePath };
+            userManager = (IUserManager) cons.newInstance(obj);
+        } catch(IOException e ) {
+            System.err.println("Could not load user file");
+            System.exit(1);
+        } catch(ClassNotFoundException e) {
+            System.err.println("Could not load User Manager class");
+            System.exit(1);
+        }  catch (NoSuchMethodException e) {
+            System.err.println("Could not load User Manager constructor");
+            System.exit(1);
+        } catch (IllegalAccessException | InstantiationException | InvocationTargetException e) {
+            System.err.println("Could not create User Manager instance");
+            System.exit(1);
+        }
+        return userManager;
+    }
+}

--- a/MessageBoardSystem/src/main/java/configuration/ConfigDriver.java
+++ b/MessageBoardSystem/src/main/java/configuration/ConfigDriver.java
@@ -40,6 +40,8 @@ public final class ConfigDriver {
         return getConfig().get(ConfigModel.DB_PASSWORD);
     }
 
+    public static String getUserManagerClassName() { return getConfig().get(ConfigModel.USER_MANAGER_CLASS_NAME); }
+
     private static Map<String, String> getConfig() {
         Map<String, String> configMap = new HashMap<>();
         try {

--- a/MessageBoardSystem/src/main/java/configuration/ConfigModel.java
+++ b/MessageBoardSystem/src/main/java/configuration/ConfigModel.java
@@ -11,4 +11,5 @@ public final class ConfigModel {
     public final static String DB_USER = "DB_USER";
     public final static String DB_PASSWORD = "DB_PASSWORD";
     public final static String PAGINATION_SIZE = "PAGINATION_SIZE";
+    public final static String USER_MANAGER_CLASS_NAME = "USER_MANAGER_CLASS_NAME";
 }

--- a/MessageBoardSystem/src/test/java/UserManagerTest.java
+++ b/MessageBoardSystem/src/test/java/UserManagerTest.java
@@ -1,6 +1,6 @@
-import business_layer.UserManager;
+import helpers.Utils;
+import separated_management.UserManager;
 import org.apache.commons.collections4.CollectionUtils;
-import org.junit.Before;
 import org.junit.Test;
 import java.util.Set;
 import java.util.HashSet;
@@ -11,47 +11,46 @@ public class UserManagerTest {
     private static final String CIRCULAR_DEPENDENCY_SAME_GROUP_DATA = "circularDependencySameGroup.json";
     private static final String MISSING_PARENT_GROUP_DATA = "missingParentData.json";
     private static final String SUCCESSFUL_USER_DATA = "successfulUser.json";
+    private static final String UNDEFINED_USER_DATA = "undefinedUserData.json";
+    private final static String UNDEFINED_GROUP_DATA = "undefinedGroupData.json";
     private static final String USER_NAME_BOB = "Bob";
     private static final String USER_NAME_MAX = "Max";
     private static final String USER_NAME_SARA = "Sara";
-    private static final String UNDEFINED_USER_DATA = "undefinedUserData.json";
-    private final static String UNDEFINED_GROUP_DATA = "undefinedGroupData.json";
-
-    UserManager userManager = null;
-
-    @Before
-    public void before() {
-        userManager = new UserManager();
-    }
 
     @Test(expected = Exception.class)
     public void testCircularDependencyDifferentGroup() throws Exception {
-        userManager.loadGroupMembership(USER_NAME_BOB, CIRCULAR_DEPENDENCY_DIFFERENT_GROUP_TEST_DATA);
+        UserManager userManager = new UserManager(Utils.buildTargetFilePath(CIRCULAR_DEPENDENCY_DIFFERENT_GROUP_TEST_DATA));
+        userManager.loadGroupMembership(USER_NAME_BOB);
     }
 
     @Test(expected = Exception.class)
     public void testCircularDependencySameGroup() throws Exception {
-        userManager.loadGroupMembership(USER_NAME_MAX, CIRCULAR_DEPENDENCY_SAME_GROUP_DATA);
+        UserManager userManager = new UserManager(Utils.buildTargetFilePath(CIRCULAR_DEPENDENCY_SAME_GROUP_DATA));
+        userManager.loadGroupMembership(USER_NAME_MAX);
     }
 
     @Test(expected = Exception.class)
     public void testMissingParentGroup() throws Exception {
-        userManager.loadGroupMembership(USER_NAME_BOB, MISSING_PARENT_GROUP_DATA);
+        UserManager userManager = new UserManager(Utils.buildTargetFilePath(MISSING_PARENT_GROUP_DATA));
+        userManager.loadGroupMembership(USER_NAME_BOB);
     }
 
     @Test(expected = Exception.class)
     public void testUndefinedUser() throws Exception {
-        userManager.loadGroupMembership(USER_NAME_BOB, UNDEFINED_USER_DATA);
+        UserManager userManager = new UserManager(Utils.buildTargetFilePath(UNDEFINED_USER_DATA));
+        userManager.loadGroupMembership(USER_NAME_BOB);
     }
 
     @Test(expected = Exception.class)
     public void testUndefinedGroup() throws Exception {
-        userManager.loadGroupMembership(USER_NAME_BOB, UNDEFINED_GROUP_DATA);
+        UserManager userManager = new UserManager(Utils.buildTargetFilePath(UNDEFINED_GROUP_DATA));
+        userManager.loadGroupMembership(USER_NAME_BOB);
     }
 
     @Test
     public void testSuccessfulUserBob() throws Exception {
-        Set<String> col1 = userManager.loadGroupMembership(USER_NAME_BOB, SUCCESSFUL_USER_DATA);
+        UserManager userManager = new UserManager(Utils.buildTargetFilePath(SUCCESSFUL_USER_DATA));
+        Set<String> col1 = userManager.loadGroupMembership(USER_NAME_BOB);
         Set<String>col2 = new HashSet<>();
         col2.add("admins");
         col2.add("concordia");
@@ -63,7 +62,8 @@ public class UserManagerTest {
 
     @Test
     public void testSuccessfulUserMax() throws Exception {
-        Set<String> col1 = userManager.loadGroupMembership(USER_NAME_MAX, SUCCESSFUL_USER_DATA);
+        UserManager userManager = new UserManager(Utils.buildTargetFilePath(SUCCESSFUL_USER_DATA));
+        Set<String> col1 = userManager.loadGroupMembership(USER_NAME_MAX);
         Set<String>col2 = new HashSet<>();
         col2.add("encs");
         col2.add("comp");
@@ -73,7 +73,8 @@ public class UserManagerTest {
 
     @Test
     public void testSuccessfulUserSara() throws Exception {
-        Set<String> col1 = userManager.loadGroupMembership(USER_NAME_SARA, SUCCESSFUL_USER_DATA);
+        UserManager userManager = new UserManager(Utils.buildTargetFilePath(SUCCESSFUL_USER_DATA));
+        Set<String> col1 = userManager.loadGroupMembership(USER_NAME_SARA);
         Set<String>col2 = new HashSet<>();
         col2.add("soen");
         assertTrue(CollectionUtils.isEqualCollection(col2, col1));


### PR DESCRIPTION
- Add `IUserManager` interface to the `business_layer`.
- Add `UserManagerFactory` to the `business_layer`
- Move `UserManager` implementation to the new `separated_management` package
- Add `USER_MANAGER_CLASS_NAME` entry to the `config.json`

`MessageBoardManager` uses the factory to get an instance of the `UserManager` class. Factory dynamically loads based on the class name specified in the configuration file. 

**REFACTORING** As per requirements `UserManager` is taking `user file path` as an argument to its constructor, so I tweaked our tests to follow this requirement