### PR TITLE
Fix view recent posts #146

### DIFF
--- a/MessageBoardSystem/src/main/java/helpers/FrontendBoardManager.java
+++ b/MessageBoardSystem/src/main/java/helpers/FrontendBoardManager.java
@@ -1,8 +1,10 @@
 package helpers;
 
+import configuration.ConfigDriver;
 import models.Post;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -25,6 +27,20 @@ public class FrontendBoardManager {
                 messageBoard.put(post.getTimestamp(), post);
             }
         });
+    }
+
+    public static void paginateMessageBoard(HttpServletRequest request) {
+        ConcurrentSkipListMap<Long, Post> messageBoard = fetchMessageBoard(request);
+        int postCount = ConfigDriver.getPaginationSize();
+        List<Post> paginatedPosts = new ArrayList<>();
+        while(postCount > 0 && !messageBoard.isEmpty()) {
+            paginatedPosts.add(messageBoard.pollFirstEntry().getValue());
+            postCount--;
+        }
+        messageBoard.clear();
+        for(Post post : paginatedPosts) {
+            messageBoard.put(post.getTimestamp(), post);
+        }
     }
 
     public static void updatePost(HttpServletRequest request, Post post) {

--- a/MessageBoardSystem/src/main/java/servlet/PaginationServlet.java
+++ b/MessageBoardSystem/src/main/java/servlet/PaginationServlet.java
@@ -22,8 +22,9 @@ public class PaginationServlet extends HttpServlet {
     }
 
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        List<Post> recentPosts = this.boardManager.getMostRecentPosts();
+        List<Post> recentPosts = this.boardManager.getAllPosts();
         FrontendBoardManager.refreshMessageBoard(request, recentPosts);
+        FrontendBoardManager.paginateMessageBoard(request);
         response.sendRedirect(ROOT_PAGE);
     }
 }


### PR DESCRIPTION
We can no longer filter recent posts on a DB level because we perform Group verification in a business layer.